### PR TITLE
fix(#11): Fix automated publishing

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -35,4 +35,4 @@ jobs:
       - run: yarn install
       - run: npm publish
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I checked [our setup](https://github.com/American-Soccer-Analysis/itscalledsoccer-js/blob/main/.github/workflows/npm-publish.yml) from `itscalledsoccer-js` and found that its `NODE_AUTH_TOKEN`, not `NPM_TOKEN`